### PR TITLE
Support HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ var config = {
             config: {
                 // See below for configurable options
                 region: 'sw',
-                apiBase: 'http://www.metoffice.gov.uk/public/data/PWSCache/WarningsRSS/Region/',
+                apiBase: 'https://www.metoffice.gov.uk/public/data/PWSCache/WarningsRSS/Region/',
         }
     ]
 }
@@ -33,7 +33,7 @@ var config = {
 
 | Option              | Description
 |-------------------- |-----------
-| `apiBase`           | *Required* UKMO Weather Warnings feed URL <br><br>**Type:** `string` <br>e.g. `http://www.metoffice.gov.uk/public/data/PWSCache/WarningsRSS/Region/`
+| `apiBase`           | *Required* UKMO Weather Warnings feed URL <br><br>**Type:** `string` <br>e.g. `https://www.metoffice.gov.uk/public/data/PWSCache/WarningsRSS/Region/`
 | `region`            | *Required* UKMO Weather Warnings Region <br><br>**Type:** `string` <br>See table below, e.g. `sw`
 | `updateInterval`    | *Optional* Update interval <br><br>**Type:** `int`(milliseconds) <br>Default 900000 milliseconds (15 minutes)
 | `retryDelay`        | *Optional* Retry delay <br><br>**Type:** `int`(milliseconds) <br>Default 5000 milliseconds (5 seconds)

--- a/node_helper.js
+++ b/node_helper.js
@@ -6,7 +6,7 @@
  * MIT Licensed.
  */
 const FeedMe = require("feedme")
-const http = require("http")
+const https = require("https")
 const moment = require("moment")
 const fs = require("fs")
 var NodeHelper = require("node_helper");

--- a/node_helper.js
+++ b/node_helper.js
@@ -41,7 +41,7 @@ module.exports = NodeHelper.create({
 	warningsRequest: function(url) {
 		self = this
 
-		http.get(url, (res) => {
+		https.get(url, (res) => {
 		  if (res.statusCode != 200) {
 		    console.error(new Error(`status code ${res.statusCode}`))
 		    return


### PR DESCRIPTION
Switch from `http.get` to `https.get`.
This function only supports either HTTP or HTTPS, but since the MET office now only supports HTTPS we should be OK to just change it.